### PR TITLE
Fix for gl-vertex-array tex-coords

### DIFF
--- a/gl/opengl.lisp
+++ b/gl/opengl.lisp
@@ -182,13 +182,13 @@
              rest
            `(progn
               (client-active-texture ,stage)
-              (tex-coord-pointer ,size ,gl-type ,stride ,address-expr))))
+              (,func-name ,size ,gl-type ,stride ,address-expr))))
         (edge-flag                      ; type is fixed
-         `(edge-flag-pointer ,stride ,address-expr))
+         `(,func-name ,stride ,address-expr))
         (vertex-attrib
          (destructuring-bind (&key (index 0) (normalized nil) &allow-other-keys)
              rest
-           `(vertex-attrib-pointer ,index ,size ,type ,normalized ,stride
+           `(,func-name ,index ,size ,type ,normalized ,stride
                                    ,address-expr)))))))
 
 (defmacro define-gl-array-format (name &body clauses)


### PR DESCRIPTION
changed function names in emit-gl-array-bind-clause for tex-coord, edge-flag, and vertex-attrib to ,func-name.  
They needed to be %gl:tex-coord-pointer, etc.
