### PR TITLE
glut:close fails to close window

### DIFF
--- a/glut/interface.lisp
+++ b/glut/interface.lisp
@@ -333,6 +333,9 @@ Lexically binds CURRENT-WINDOW to the respective object."
   #+darwin
   (when (not (destroyed w))
     (setf (destroyed w) t)
+    ;; Apple's GLUT doesn't actually close the window when its close
+    ;; button is pressed. So we ensure it's destroyed, otherwise it'll
+    ;; hang around indefinitely not listening to events.
     (destroy-window (id w)))
   (when (null *windows-with-idle-event*)
     (unregister-callback (find-event-or-lose :idle)))


### PR DESCRIPTION
I'm running through some examples on http://nklein.com/tags/opengl/ and fail to get (glut:close win) to close the window.  It does stop the glut processes from executing, but the window hangs around.  It looks like calling glut:close is the proper thing per the interface.lisp file, however, hitting #/q or manually entering a glut:close command fails.  Is there something I am missing?

I see that I can use glut:destroy-current-window....but I would expect glut:close to work.

Running on Ubuntu 10.10, SBCL 1.0.40.0.debian
https://github.com/3b/cl-opengl.git
master
