### PR TITLE
Added fallback for gl-get-proc-address to use the cffi equivalent.

### DIFF
--- a/gl/bindings.lisp
+++ b/gl/bindings.lisp
@@ -113,7 +113,8 @@
 (defun gl-get-proc-address (name)
   (funcall (or *gl-get-proc-address*
                #+linux #'glx-get-proc-address
-               #+win32 #'wgl-get-proc-address)
+               #+win32 #'wgl-get-proc-address
+               #'cffi:foreign-symbol-pointer)
            name))
 
 (eval-when (:load-toplevel :execute)


### PR DESCRIPTION
On MacOSX I ran into issues that it could not find certain function,  I traced it to the fact that there was no function to resolve the address of the opengl extension functions.

The cffi:foreign-symbol-pointer worked and because cffi is already used by cl-opengl I added it as the default fallback function.

For me this works. 

Kind regards,
Wim Oudshoorn.