### PR TITLE
Check in a various query functions if the length of the resulting string...

### DIFF
--- a/gl/state.lisp
+++ b/gl/state.lisp
@@ -1250,25 +1250,31 @@ currently implemented for speed, so avoid in inner loops"
             collecting (mem-aref shaders '%gl:uint i)))))
 
 (defun get-shader-info-log (shader)
-  "Returns as a string the entire info log for SHADER"
+  "Returns as a string the entire info log for SHADER.
+If there is no string to return because there is no info log, return nil"
   (let ((info-log-length (get-shader shader :info-log-length)))
-    (with-foreign-object (info-log '%gl:char info-log-length)
-      (%gl:get-shader-info-log shader info-log-length (null-pointer) info-log)
-      (foreign-string-to-lisp info-log))))
+    (when (> info-log-length 0)
+      (with-foreign-object (info-log '%gl:char info-log-length)
+        (%gl:get-shader-info-log shader info-log-length (null-pointer) info-log)
+        (foreign-string-to-lisp info-log)))))
 
 (defun get-program-info-log (program)
-  "Returns as a string the entire info log for PROGRAM"
+  "Returns as a string the entire info log for PROGRAM.
+If there is no string to return because there is no info log, return nil"
   (let ((info-log-length (get-program program :info-log-length)))
-    (with-foreign-object (info-log '%gl:char info-log-length)
-      (%gl:get-program-info-log program info-log-length (null-pointer) info-log)
-      (foreign-string-to-lisp info-log))))
+    (when (> info-log-length)
+      (with-foreign-object (info-log '%gl:char info-log-length)
+        (%gl:get-program-info-log program info-log-length (null-pointer) info-log)
+        (foreign-string-to-lisp info-log)))))
 
 (defun get-shader-source (shader)
-  "Returns as a string the entire source of SHADER"
+  "Returns as a string the entire source of SHADER.
+Returns nil if there is no source available."
   (let ((source-length (get-shader shader :shader-source-length)))
-    (with-foreign-object (source '%gl:char source-length)
-      (%gl:get-shader-source shader source-length (null-pointer) source)
-      (foreign-string-to-lisp source))))
+    (when (> source-length 0)
+      (with-foreign-object (source '%gl:char source-length)
+        (%gl:get-shader-source shader source-length (null-pointer) source)
+        (foreign-string-to-lisp source)))))
 
 ;;; 6.1.15 Saving and Restoring State
 

--- a/gl/state.lisp
+++ b/gl/state.lisp
@@ -1262,7 +1262,7 @@ If there is no string to return because there is no info log, return nil"
   "Returns as a string the entire info log for PROGRAM.
 If there is no string to return because there is no info log, return nil"
   (let ((info-log-length (get-program program :info-log-length)))
-    (when (> info-log-length)
+    (when (> info-log-length 0)
       (with-foreign-object (info-log '%gl:char info-log-length)
         (%gl:get-program-info-log program info-log-length (null-pointer) info-log)
         (foreign-string-to-lisp info-log)))))


### PR DESCRIPTION
When I call get-shader-info-log when no error or warning was created compiling the shader, I get a segfault with CCL on MacOSX.  I did not really track it down, but I assume that the allocation of a zero length array returns something unsuitable, or that the OpenGL library on OSX does not handle it gracefully.

I have modified the get-shader-info-log function (and 2 other functions nearby that also return strings.) to check if the length is > 0 .   If the length of the string is 0 the function will now return nil.  

I am not sure if returning nil or "" is better.  However for me at the moment it seem easier to discard a log entry when it return 'nil' instead of checking on the "" (empty string).

Kind regards,
Wim Oudshoorn. 