### PR TITLE
Added definitions for Shift,Ctrl,Alt special keys

### DIFF
--- a/gl/bindings.lisp
+++ b/gl/bindings.lisp
@@ -106,14 +106,14 @@
 #+linux
 (defcfun ("glXGetProcAddress" glx-get-proc-address) :pointer
   (proc-name :string))
-#+win32
+#+windows
 (defcfun ("wglGetProcAddress" wgl-get-proc-address) :pointer
   (proc-name :string))
 
 (defun gl-get-proc-address (name)
   (funcall (or *gl-get-proc-address*
                #+linux #'glx-get-proc-address
-               #+win32 #'wgl-get-proc-address)
+               #+windows #'wgl-get-proc-address)
            name))
 
 (eval-when (:load-toplevel :execute)

--- a/glut/callbacks.lisp
+++ b/glut/callbacks.lisp
@@ -244,7 +244,14 @@
   :key-page-down
   :key-home
   :key-end
-  :key-insert)
+  :key-insert
+  ;; Modifiers keys
+  (:key-left-shift 112)
+  :key-right-shift
+  :key-left-ctrl
+  :key-right-ctrl
+  :key-left-alt
+  :key-right-alt)
 
 (defcenum visibility-state
   :not-visible


### PR DESCRIPTION
Otherwise when definiting glut:special and glut:special-up methods it signals:
Error: 112 is not defined as a value for enum type #<FOREIGN-ENUM CL-GLUT:SPECIAL-KEYS>
Checked on Windows and Linux.

and a cleanup: fixed conditional: #+win32 -> #+windows (ccl does not define win32 on win 64). This has not caused any issue as _gl-get-proc-address_ is set elsewhere, but it is the only occurence of win32 conditional in cl-opengl.
