### PR TITLE
added get-uniform-block-index convenience function

### DIFF
--- a/gl/extensions.lisp
+++ b/gl/extensions.lisp
@@ -102,3 +102,11 @@
     (:framebuffer )))
 
 (import-export %gl:generate-mipmap %gl:generate-mipmap-ext)
+
+;;;
+;;; ARB_uniform_buffer_object
+;;;
+
+(defun get-uniform-block-index (program uniformblockname)
+  (with-foreign-string (s uniformblockname)
+    (%gl:get-uniform-block-index program s)))

--- a/gl/package.lisp
+++ b/gl/package.lisp
@@ -375,4 +375,6 @@
    #:uniform-matrix-4x2-fv
    #:uniform-matrix-4x3-fv
    #:uniform-matrix-4fv
-   #:uniformiv))
+   #:uniformiv
+   ;; ARB_* Extensions
+   #:get-uniform-block-index))

--- a/gl/package.lisp
+++ b/gl/package.lisp
@@ -360,8 +360,11 @@
    #:generate-mipmap-ext
    #:with-pushed-matrix*
    #:uniformfv
+   #:tex-parameter
    #:get-tex-parameter
    #:get-tex-level-parameter
+   #:gen-samplers
+   #:sampler-parameter
    #:gen-framebuffers
    #:delete-framebuffers
    #:gen-renderbuffers

--- a/gl/rasterization.lisp
+++ b/gl/rasterization.lisp
@@ -303,7 +303,7 @@
           t))
   (defun sampler-parameter (sampler pname param)
     (body sampler
-          %gl:tex-parameter-i %gl:tex-parameter-f %gl:tex-parameter-fv)))
+          %gl:sampler-parameter-i %gl:sampler-parameter-f %gl:sampler-parameter-fv)))
 
 ;;; 3.8.12 Texture Objects
 


### PR DESCRIPTION
The %gl:get-uniform-block-index function is frequently needed to work with the http://www.arcsynthesis.org/gltut/ tutorial and may hence help newcomers to opengl/cl-opengl

After reviewing the code I hope I came to the right conclusion to put it into extensions.lisp, not sure
if I should've add IMPORT-EXPORT for all the other functions specified in ARB_uniform_buffer_object extension or if it would be better to create an own file for this like "ARB-extensions.lisp"