### PR TITLE
make open-gl-examples compatible with case-sensitive lisp

### DIFF
--- a/gl/opengl.lisp
+++ b/gl/opengl.lisp
@@ -168,7 +168,9 @@
   (destructuring-bind (array-type &rest rest &key type components
                                   &allow-other-keys)
       clause
-    (let ((func-name (symbolicate-package "%GL" array-type "-POINTER"))
+    (let ((func-name (symbolicate-package (princ-to-string '%gl)
+                                          array-type
+                                          (princ-to-string '-pointer)))
           (gl-type (cffi-type-to-gl type))
           (address-expr `(inc-pointer ,psym ,offset))
           (size (length components)))


### PR DESCRIPTION
Hi the examples wouldn't compile on case-sensitive windows allegro 64 bit version.  I was able to fix this bug by using the lisp reader to generate the strings "%GL" and "-POINTER" 

This way the case of these strings will always match the rest of the source code regardless whether the  reader is case-sensitive or not...