### PR TITLE
unquote name in get* compiler-macro

### DIFF
--- a/gl/state.lisp
+++ b/gl/state.lisp
@@ -1065,7 +1065,7 @@
               ;;  don't want to just call the indexed query with 0
               ;;  when no index was provided)
               (:integer/i (if indexp
-                              `(get-integer-i name ,index size)
+                              `(get-integer-i ,name ,index size)
                               `(get-integer ,name size)))
               (:integer64/i (if indexp
                                 `(get-integer-64-i ,name ,index size)


### PR DESCRIPTION
Just fixes a small mistake in get*. The case for :integer/i when indexp
is true emits `name` without unquoting it.