### PR TITLE
reader conditional fix

### DIFF
--- a/gl/bindings.lisp
+++ b/gl/bindings.lisp
@@ -128,7 +128,7 @@
   (funcall (or *gl-get-proc-address*
                #+(or linux freebsd) #'glx-get-proc-address
                #+windows #'wgl-get-proc-address
-               #'cffi:foreign-symbol-pointer)
+               #-(or linux freebsd windows) #'cffi:foreign-symbol-pointer)
            name))
 
 (eval-when (:load-toplevel :execute)


### PR DESCRIPTION
The feature partitions need to never overlap in such a case to prevent dead code elimination compiler output noise.