### PR TITLE
Fix CFFI warnings of deprecated usage of bare references to structs

### DIFF
--- a/examples/misc/opengl-array.lisp
+++ b/examples/misc/opengl-array.lisp
@@ -8,7 +8,7 @@
 
 (defclass opengl-array-window (glut:window)
   ((vertex-array :accessor vertex-array
-                 :initform (gl:alloc-gl-array 'position-color 5))
+                 :initform (gl:alloc-gl-array '(:struct position-color) 5))
    (indices-array :accessor indices-array
                   :initform (gl:alloc-gl-array :unsigned-short 10)))
   (:default-initargs :title "opengl-array.lisp"))


### PR DESCRIPTION
As a consequence, alloc-gl-array now takes proper cffi struct types as well as primitive types. Therefore, one has to write:
  (gl:alloc-gl-array '(:struct position-color) 5)
instead of
  (gl:alloc-gl-array 'position-color 5)

Closes #41