### PR TITLE
Use the cl-user::*foreign-system-libraries* hook from Deploy

### DIFF
--- a/gl/library-glesv2.lisp
+++ b/gl/library-glesv2.lisp
@@ -27,5 +27,10 @@
 (define-foreign-library opengl
   (t (:or (:default "libGLESv3") (:default "libGLESv2"))))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(opengl)))
+
 (unless (member :cl-opengl-no-preload *features*)
   (use-foreign-library opengl))

--- a/gl/library.lisp
+++ b/gl/library.lisp
@@ -37,6 +37,10 @@
   (:windows "opengl32.dll" :convention :stdcall)
   (:unix (:or "libGL.so.4" "libGL.so.3" "libGL.so.2" "libGL.so.1" "libGL.so")))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(opengl)))
 
 (unless (member :cl-opengl-no-preload *features*)
   (use-foreign-library opengl))

--- a/glu/library.lisp
+++ b/glu/library.lisp
@@ -39,4 +39,9 @@
   ((:and :unix (:not :darwin)) (:or "libGLU.so.1" "libGLU.so"))
   ((:not :darwin) (:default "libGLU")))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(glu)))
+
 (use-foreign-library glu)

--- a/glut/library.lisp
+++ b/glut/library.lisp
@@ -37,4 +37,9 @@
   (:windows (:or "freeglut.dll" "libglut.dll" "libglut-0.dll" "libfreeglut.dll"))
   (:unix (:or "libglut.so" "libglut.so.3")))
 
+(set 'cl-user::*foreign-system-libraries*
+     (union (when (boundp 'cl-user::*foreign-system-libraries*)
+              (symbol-value 'cl-user::*foreign-system-libraries*))
+            '(glut)))
+
 (use-foreign-library glut)


### PR DESCRIPTION
Hey! This small PR integrates `cl-opengl` better with [Deploy](https://github.com/Shinmera/deploy) tool. When this tool is not used, no harm's done — there's just the variable `*foreign-system-libraries*` created in `cl-user` package. When it is used though, [this prevents](https://github.com/Shinmera/deploy?tab=readme-ov-file#marking-system-libraries-as-a-library-author) Deploy from unnecessarily copying system libraries (which opengl libs are) into deployment directory.