### PR TITLE
Add missing gl:tex-env pname handling when target is :texture-env

### DIFF
--- a/gl/rasterization.lisp
+++ b/gl/rasterization.lisp
@@ -483,9 +483,15 @@
             (dotimes (i 4)
               (setf (mem-aref p '%gl:float i) (elt value i)))
             (%gl:tex-env-fv target pname p)))
-         (:combine-rgb
+         ((:combine-rgb :combine-alpha)
           (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
-         (:combine-alpha
+         ((:rgb-scale :alpha-scale)
+          (%gl:tex-env-f target pname value))
+         ((:src0-rgb :src1-rgb :src2-rgb
+                     :source0-rgb :source1-rgb :source2-rgb)
+          (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
+         ((:src0-alpha :src1-alpha :src2-alpha
+                       :source0-alpha :source1-alpha :source2-alpha)
           (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))))
 
      (:point-sprite

--- a/gl/rasterization.lisp
+++ b/gl/rasterization.lisp
@@ -494,9 +494,9 @@
                        :source0-alpha :source1-alpha :source2-alpha)
           (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))))
 
-     (:point-sprite
-      (ecase pname
-        (:coord-replace (%gl:tex-env-i target pname (if value 1 0))))))))
+      (:point-sprite
+       (ecase pname
+         (:coord-replace (%gl:tex-env-i target pname (if value 1 0))))))))
 
 ;;; texture queries
 (macrolet ((with-getters ((f i &rest vars) &body body)

--- a/gl/rasterization.lisp
+++ b/gl/rasterization.lisp
@@ -469,34 +469,33 @@
 ;;; Ye gods, have mercy!
 
 (defun tex-env (target pname value)
-  (let (pname-value)
-    (ecase target
-      (:texture-filter-control
-       (ecase pname
-         (:texture-lod-bias (%gl:tex-env-f target pname value))))
-      (:texture-env
-       (ecase pname
-         (:texture-env-mode
-          (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
-         (:texture-env-color
-          (with-foreign-object (p '%gl:float 4)
-            (dotimes (i 4)
-              (setf (mem-aref p '%gl:float i) (elt value i)))
-            (%gl:tex-env-fv target pname p)))
-         ((:combine-rgb :combine-alpha)
-          (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
-         ((:rgb-scale :alpha-scale)
-          (%gl:tex-env-f target pname value))
-         ((:src0-rgb :src1-rgb :src2-rgb
-                     :source0-rgb :source1-rgb :source2-rgb)
-          (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
-         ((:src0-alpha :src1-alpha :src2-alpha
-                       :source0-alpha :source1-alpha :source2-alpha)
-          (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))))
+  (ecase target
+    (:texture-filter-control
+     (ecase pname
+       (:texture-lod-bias (%gl:tex-env-f target pname value))))
+    (:texture-env
+     (ecase pname
+       (:texture-env-mode
+        (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
+       (:texture-env-color
+        (with-foreign-object (p '%gl:float 4)
+          (dotimes (i 4)
+            (setf (mem-aref p '%gl:float i) (elt value i)))
+          (%gl:tex-env-fv target pname p)))
+       ((:combine-rgb :combine-alpha)
+        (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
+       ((:rgb-scale :alpha-scale)
+        (%gl:tex-env-f target pname value))
+       ((:src0-rgb :src1-rgb :src2-rgb
+                   :source0-rgb :source1-rgb :source2-rgb)
+        (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))
+       ((:src0-alpha :src1-alpha :src2-alpha
+                     :source0-alpha :source1-alpha :source2-alpha)
+        (%gl:tex-env-i target pname (foreign-enum-value '%gl:enum value)))))
 
-      (:point-sprite
-       (ecase pname
-         (:coord-replace (%gl:tex-env-i target pname (if value 1 0))))))))
+    (:point-sprite
+     (ecase pname
+       (:coord-replace (%gl:tex-env-i target pname (if value 1 0)))))))
 
 ;;; texture queries
 (macrolet ((with-getters ((f i &rest vars) &body body)


### PR DESCRIPTION
I know most of the world has moved on to shader land but having these missing `gl:tex-env` pnames would be useful to me. I used https://docs.gl/gl3/glTexEnv as the reference, which I think is just a prettier version of the spec itself.

Within the `cond` , the added pnames are grouped either by `-rgb`, `-alpha`, `-scale`, or `combine-` even though they all dispatch to the same call.

I wasn't sure about the whitespace and project standards... happy to have it squashed in